### PR TITLE
Upgrade visualisation dependency to support audio nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "svg-inline-react": "1",
-    "visualise-videocontext": "^1.0.1"
+    "visualise-videocontext": "^1.2.2"
   }
 }


### PR DESCRIPTION
This is a follow up on the PR i made in the [bbc/visualise-videocontext](https://github.com/bbc/visualise-videocontext) repo https://github.com/bbc/visualise-videocontext/pull/12